### PR TITLE
Add --dependencies-only option for start

### DIFF
--- a/lib/locald/cli.py
+++ b/lib/locald/cli.py
@@ -61,6 +61,12 @@ class App(object):
 
         start_parser.add_argument("name")
 
+        start_parser.add_argument(
+            "--dependencies-only",
+            help="only start dependencies",
+            action="store_true",
+        )
+
         stop_parser = subparsers.add_parser("stop")
         stop_parser.set_defaults(func=self.stop)
 
@@ -114,7 +120,7 @@ class App(object):
 
     def start(self, config, args):
         client = Client(config)
-        client.start(args.name, quiet=args.quiet)
+        client.start(args.name, quiet=args.quiet, dependencies_only=args.dependencies_only)
 
     def stop(self, config, args):
         client = Client(config)

--- a/lib/locald/client.py
+++ b/lib/locald/client.py
@@ -63,11 +63,12 @@ class Client(object):
 
         return response
 
-    def start(self, name, quiet=False):
+    def start(self, name, quiet=False, dependencies_only=False):
 
         command = {
             "command": "start",
             "name": name,
+            "dependencies_only": dependencies_only,
         }
 
         response = self.send_command(command)

--- a/lib/locald/server.py
+++ b/lib/locald/server.py
@@ -206,19 +206,20 @@ class Server(object):
     def handle_start(self, command):
 
         name = command["name"]
+        dependencies_only = command.get("dependencies_only", False)
 
         if name not in self.config:
             return {
                 "messages": ["unknown service '{}'".format(name)],
             }
 
-        messages, _ = self.start_service(name)
+        messages, _ = self.start_service(name, dependencies_only)
 
         return {
             "messages": messages,
         }
 
-    def start_service(self, name):
+    def start_service(self, name, dependencies_only=False):
 
         service_config = get_config_for_service(self.config, name)
 
@@ -239,13 +240,15 @@ class Server(object):
             if is_error:
                 return messages, True
 
-        if name not in self.processes:
-            proc = Service(name, service_config)
-            self.processes[name] = proc
+        if not dependencies_only:
 
-        self.processes[name].start()
+            if name not in self.processes:
+                proc = Service(name, service_config)
+                self.processes[name] = proc
 
-        messages.append("started '{}'".format(name))
+            self.processes[name].start()
+
+            messages.append("started '{}'".format(name))
 
         return messages, False
 


### PR DESCRIPTION
`locald start <service> --dependencies-only` starts on the service's dependencies, not the service itself.